### PR TITLE
Added fix to deal with CPM: extensible SizeConstraint

### DIFF
--- a/libasn1fix/asn1fix_constraint.c
+++ b/libasn1fix/asn1fix_constraint.c
@@ -237,6 +237,9 @@ _remove_extensions(arg_t *arg, asn1p_constraint_t *ct, int forgive_last) {
 	unsigned int i;
 
 	if(!ct) return;
+	
+	/* Keep extensible SizeConstraint */
+	if(ct->type == ACT_CT_SIZE && forgive_last) return;
 
 	for(i = 0; i < ct->el_count; i++) {
 		if(ct->elements[i]->type == ACT_EL_EXT)


### PR DESCRIPTION
UPER encoded CPMs caused decoding failures by the generated headers. 
Issue already described here: https://github.com/vlm/asn1c/issues/433
Proposed fix is this commit: https://github.com/riebl/asn1c/commit/c35ebd330b7c7e15c1bd61c9782e4259bd9bcb03
 